### PR TITLE
Refactor observers & Decoupling GameView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ logs/
 .qodo
 
 # Ignore command log files
-/src/main/resources/configuration/command_log.json
+src/main/resources/configuration/command_log.json

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/commands/GameSwipeCommand.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/commands/GameSwipeCommand.java
@@ -7,7 +7,10 @@ import nl.vu.cs.ancientegyptiansgame.data.enums.SwipeSide;
 import nl.vu.cs.ancientegyptiansgame.data.model.Ending;
 import nl.vu.cs.ancientegyptiansgame.handlers.HandleInfluencePillars;
 import nl.vu.cs.ancientegyptiansgame.data.model.Card;
-import nl.vu.cs.ancientegyptiansgame.ui.views.GameView;
+import nl.vu.cs.ancientegyptiansgame.handlers.HandleScore;
+import nl.vu.cs.ancientegyptiansgame.listeners.EndingListener;
+import nl.vu.cs.ancientegyptiansgame.observer.ScoreObserver;
+import nl.vu.cs.ancientegyptiansgame.observer.YearsInPowerObserver;
 import nl.vu.cs.ancientegyptiansgame.controller.GameStateController;
 import nl.vu.cs.ancientegyptiansgame.logging.CommandLogger;
 import nl.vu.cs.ancientegyptiansgame.logging.GameCommandLogEntry;
@@ -17,53 +20,55 @@ public class GameSwipeCommand implements Command {
     private final SwipeSide side;
     private final Card card;
     private final ScoreSettings scoreSettings;
-    private final GameView gameView;
     private final GameStateController gameStateController;
     private final HandleInfluencePillars handleInfluencePillars;
     private final GameConfiguration gameConfiguration;
+    private final EndingListener endingListener;
 
-    public GameSwipeCommand(SwipeSide side, GameStateController gameStateController, GameView gameView) {
+    public GameSwipeCommand(SwipeSide side, GameStateController gameStateController, EndingListener listener) {
         this.side = side;
         this.card = gameStateController.getCurrentGameCard();
         this.gameStateController = gameStateController;
         this.scoreSettings = gameStateController.getScoreSettings();
         this.handleInfluencePillars = new HandleInfluencePillars();
-        this.gameView = gameView;
         this.gameConfiguration = GameConfiguration.getInstance();
+        this.endingListener = listener;
     }
 
     @Override
     public void execute() {
-        int currentYear = gameStateController.getYearCount();
+        YearsInPowerObserver yearsObserver = gameConfiguration.getYearsInPowerObserver();
+        ScoreObserver scoreObserver = gameConfiguration.getScoreObserver();
+        int currentYear = yearsObserver.getYearsInPower();
         int newYear = currentYear + scoreSettings.getYearCountIncrease();
-        gameStateController.setYearCount(newYear);
+        yearsObserver.setYearsInPower(newYear);
 
         if (newYear >= scoreSettings.getScoreConfig().getMaximumYearCount()) {
-            gameView.showEndScreen(ConfigurationLoader.getInstance().getGoldenAgeEnding());
+            if (endingListener != null) {
+                endingListener.onEndingTriggered(ConfigurationLoader.getInstance().getGoldenAgeEnding());
+            }
         }
+
+        HandleScore handleScore = new HandleScore();
+        handleScore.updateScore(scoreSettings);
         handleInfluencePillars.applyInfluence(side, card.getInfluence());
 
-        gameView.updateScore();
-        gameView.updateScoreAndYearBoxes();
         if (gameStateController.getNextCard() == null) {
             Ending badEnding = ConfigurationLoader.getInstance().getBadEnding();
-            if (badEnding != null) {
-                gameView.showEndScreen(badEnding);
+            if (endingListener != null && badEnding != null) {
+                endingListener.onEndingTriggered(badEnding);
             }
         }
 
         gameStateController.updateLegacyState(card.getPillar(), side);
-
-        int currentScore = gameConfiguration.getScoreCount();
-        int currentYearCount = gameConfiguration.getYearCount();
 
         GameCommandLogEntry entry = new GameCommandLogEntry(
                 card.getTitle(),
                 side.toString(),
                 card.getInfluence(),
                 System.currentTimeMillis(),
-                currentScore,
-                currentYearCount
+                scoreObserver.getScore(),
+                yearsObserver.getYearsInPower()
         );
         CommandLogger.logCommand(entry);
     }

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/config/ConfigurationLoader.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/config/ConfigurationLoader.java
@@ -10,7 +10,9 @@ import nl.vu.cs.ancientegyptiansgame.exception.ConfigurationNotFoundException;
 import nl.vu.cs.ancientegyptiansgame.exception.InvalidPillarConfigurationException;
 
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ConfigurationLoader {
     private static ConfigurationLoader instance;
@@ -18,6 +20,7 @@ public class ConfigurationLoader {
 
     private Ending goldenAgeEnding;
     private Ending badEnding;
+    private Map<String, Ending> pillarEndings = new HashMap<>();
     private ScoreSettings scoreSettings;
     private List<Mode> modes;
     private List<String> monarchs;
@@ -63,9 +66,10 @@ public class ConfigurationLoader {
         JsonNode pillarsNode = root.get("pillars");
         if (pillarsNode != null && pillarsNode.isArray()) {
             for (JsonNode pillarNode : pillarsNode) {
-                String name = pillarNode.get("name").asText().toLowerCase();
+                String name = pillarNode.get("name").asText().toUpperCase();
                 try {
-                    mapper.convertValue(pillarNode.get("ending"), Ending.class);
+                    Ending ending = mapper.convertValue(pillarNode.get("ending"), Ending.class);
+                    pillarEndings.put(name, ending);
                 } catch (IllegalArgumentException e) {
                     throw new InvalidPillarConfigurationException("Unknown pillar name in configuration: " + name, e);
                 }
@@ -79,6 +83,10 @@ public class ConfigurationLoader {
 
     public Ending getBadEnding() {
         return badEnding;
+    }
+
+    public Ending getPillarEnding(String pillarName) {
+        return pillarEndings.get(pillarName.toUpperCase());
     }
 
     public ScoreSettings getScoreSettings() {

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/config/gamesettings/GameConfiguration.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/config/gamesettings/GameConfiguration.java
@@ -4,6 +4,8 @@ import nl.vu.cs.ancientegyptiansgame.config.scoresettings.ScoreConfig;
 import nl.vu.cs.ancientegyptiansgame.config.scoresettings.ScoreSettings;
 import nl.vu.cs.ancientegyptiansgame.data.model.Card;
 import nl.vu.cs.ancientegyptiansgame.data.model.Monarch;
+import nl.vu.cs.ancientegyptiansgame.observer.ScoreObserver;
+import nl.vu.cs.ancientegyptiansgame.observer.YearsInPowerObserver;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,7 +19,8 @@ public class GameConfiguration {
     private List<Card> cards;
     private int scoreCount;
     private int yearCount;
-
+    private final ScoreObserver scoreObserver = new ScoreObserver();
+    private final YearsInPowerObserver yearsInPowerObserver = new YearsInPowerObserver();
     private GameConfiguration() {
     }
 
@@ -58,27 +61,19 @@ public class GameConfiguration {
         this.yearCount = scoreConfig.getInitialYearCount();
     }
 
-    public int getScoreCount() {
+    public int getInitialScoreCount() {
         return scoreCount;
     }
 
-    public void setScoreCount(int scoreCount) {
-        this.scoreCount = scoreCount;
-    }
-
-    public int getYearCount() {
+    public int getInitialYearCount() {
         return yearCount;
     }
 
-    public void setYearCount(int yearCount) {
-        this.yearCount = yearCount;
+    public ScoreObserver getScoreObserver() {
+        return scoreObserver;
     }
 
-    public void incrementYearCount(int increment) {
-        this.yearCount += increment;
-    }
-
-    public void incrementScoreCount(int increment) {
-        this.scoreCount += increment;
+    public YearsInPowerObserver getYearsInPowerObserver() {
+        return yearsInPowerObserver;
     }
 }

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/controller/GameStateController.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/controller/GameStateController.java
@@ -178,11 +178,4 @@ public class GameStateController {
         return scoreSettings;
     }
 
-    public int getYearCount() {
-        return gameConfiguration.getYearCount();
-    }
-
-    public void setYearCount(int newYearCount) {
-        gameConfiguration.setYearCount(newYearCount);
-    }
 }

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/data/model/PillarData.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/data/model/PillarData.java
@@ -20,6 +20,10 @@ public class PillarData {
         listeners.add(listener);
     }
 
+    public void increaseValue(Integer increment) {
+        setValue(value + increment);
+    }
+
     public Integer getValue() {
         return value;
     }

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/data/model/Pillars.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/data/model/Pillars.java
@@ -1,34 +1,34 @@
-package nl.vu.cs.ancientegyptiansgame.data.model;
+    package nl.vu.cs.ancientegyptiansgame.data.model;
 
-public enum Pillars {
-    PRIESTS("priests", "priests.png", "priests-card.png", new Ending("The gods abandon us, Pharaoh! Your neglect of religious rites and offerings angers the temple priests. They declare you a false Pharaoh, and civil unrest splits Egypt into rival factions.", "endings/temple-priest-ending.png")),
-    FARMERS("farmers", "farmers.png", "farmers-card.png", new Ending("The nobles rule in all but name, great Pharaoh. By granting them too much power, you create a system where they control the wealth and land. Eventually, they overthrow your rule, and Egypt fractures.", "endings/farmers-ending.png")),
-    NOBLES("nobles", "nobles.png", "nobles-card.png", new Ending("The fields are empty, and the monuments crumble. Overworking the farmers and laborers breaks their spirits, leading to revolt. Egypt enters a dark age of ruin and famine.", "endings/nobles-ending.png")),
-    MILITARY("military", "military.png", "military-card.png", new Ending("The generals no longer answer to you. Discontent among the commanders leads to a military coup, and a warlord-king takes your place. Egypt enters an age of martial law and unrest.", "endings/military-ending.png"));
+    public enum Pillars {
+        PRIESTS("priests", "priests.png", "priests-card.png", new Ending("The gods abandon us, Pharaoh! Your neglect of religious rites and offerings angers the temple priests. They declare you a false Pharaoh, and civil unrest splits Egypt into rival factions.", "endings/temple-priest-ending.png")),
+        FARMERS("farmers", "farmers.png", "farmers-card.png", new Ending("The nobles rule in all but name, great Pharaoh. By granting them too much power, you create a system where they control the wealth and land. Eventually, they overthrow your rule, and Egypt fractures.", "endings/farmers-ending.png")),
+        NOBLES("nobles", "nobles.png", "nobles-card.png", new Ending("The fields are empty, and the monuments crumble. Overworking the farmers and laborers breaks their spirits, leading to revolt. Egypt enters a dark age of ruin and famine.", "endings/nobles-ending.png")),
+        MILITARY("military", "military.png", "military-card.png", new Ending("The generals no longer answer to you. Discontent among the commanders leads to a military coup, and a warlord-king takes your place. Egypt enters an age of martial law and unrest.", "endings/military-ending.png"));
 
-    private final String name;
-    private final String image;
-    private final String cardImage;
-    private final Ending ending;
+        private final String name;
+        private final String image;
+        private final String cardImage;
+        private final Ending ending;
 
-    Pillars(String name, String image, String cardImage, Ending ending) {
-        this.name = name;
-        this.image = image;
-        this.cardImage = cardImage;
-        this.ending = ending;
-    }
-
-    public String getName() { return name; }
-    public String getImage() { return image; }
-    public String getCardImage() { return cardImage; }
-    public Ending getEnding() { return ending; }
-
-    public static Pillars fromName(String name) {
-        for (Pillars pillars : values()) {
-            if (pillars.getName().equalsIgnoreCase(name)) {
-                return pillars;
-            }
+        Pillars(String name, String image, String cardImage, Ending ending) {
+            this.name = name;
+            this.image = image;
+            this.cardImage = cardImage;
+            this.ending = ending;
         }
-        throw new IllegalArgumentException("Unknown Pillars: " + name);
+
+        public String getName() { return name; }
+        public String getImage() { return image; }
+        public String getCardImage() { return cardImage; }
+        public Ending getEnding() { return ending; }
+
+        public static Pillars fromName(String name) {
+            for (Pillars pillars : values()) {
+                if (pillars.getName().equalsIgnoreCase(name)) {
+                    return pillars;
+                }
+            }
+            throw new IllegalArgumentException("Unknown Pillars: " + name);
+        }
     }
-}

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/handlers/EndingHandler.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/handlers/EndingHandler.java
@@ -5,24 +5,26 @@ import nl.vu.cs.ancientegyptiansgame.config.gamesettings.GameConfiguration;
 import nl.vu.cs.ancientegyptiansgame.config.scoresettings.ScoreSettings;
 import nl.vu.cs.ancientegyptiansgame.data.model.Ending;
 import nl.vu.cs.ancientegyptiansgame.data.model.Pillars;
+import nl.vu.cs.ancientegyptiansgame.listeners.EndingListener;
 import nl.vu.cs.ancientegyptiansgame.listeners.PillarListener;
-import nl.vu.cs.ancientegyptiansgame.ui.views.GameView;
+import nl.vu.cs.ancientegyptiansgame.observer.YearsInPowerObserver;
 
 public class EndingHandler implements PillarListener {
 
     private final GameConfiguration gameConfiguration;
     private final ScoreSettings scoreSettings;
-    private final GameView gameView;
+    private final EndingListener endingListener;
 
-    public EndingHandler(ScoreSettings scoreSettings, GameView gameView) {
+    public EndingHandler(ScoreSettings scoreSettings, EndingListener endingListener) {
         this.gameConfiguration = GameConfiguration.getInstance();
         this.scoreSettings = scoreSettings;
-        this.gameView = gameView;
+        this.endingListener = endingListener;
     }
 
     @Override
     public void changed(Pillars pillars, Integer newValue) {
-        int yearCount = gameConfiguration.getYearCount();
+        YearsInPowerObserver yearsObserver = gameConfiguration.getYearsInPowerObserver();
+        int yearCount = yearsObserver.getYearsInPower();
         int threshold = scoreSettings.getScoreConfig().getYearThreshold();
 
         boolean gameOverTriggered = false;
@@ -39,8 +41,8 @@ public class EndingHandler implements PillarListener {
                     ? ConfigurationLoader.getInstance().getGoldenAgeEnding()
                     : pillars.getEnding();
 
-            if (ending != null) {
-                gameView.showEndScreen(ending);
+            if (ending != null && endingListener != null) {
+                endingListener.onEndingTriggered(ending);
             }
         }
     }

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/handlers/HandleScore.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/handlers/HandleScore.java
@@ -1,11 +1,13 @@
 package nl.vu.cs.ancientegyptiansgame.handlers;
 
 import nl.vu.cs.ancientegyptiansgame.config.gamesettings.GameConfiguration;
+import nl.vu.cs.ancientegyptiansgame.config.gamesettings.ModeConfiguration;
 import nl.vu.cs.ancientegyptiansgame.config.scoresettings.BonusConfig;
 import nl.vu.cs.ancientegyptiansgame.config.scoresettings.ScoreSettings;
 import nl.vu.cs.ancientegyptiansgame.data.model.Pillars;
 import nl.vu.cs.ancientegyptiansgame.data.model.PillarData;
-import nl.vu.cs.ancientegyptiansgame.config.gamesettings.ModeConfiguration;
+import nl.vu.cs.ancientegyptiansgame.observer.ScoreObserver;
+import nl.vu.cs.ancientegyptiansgame.observer.YearsInPowerObserver;
 
 import java.util.List;
 
@@ -20,8 +22,11 @@ public class HandleScore {
 
     public void updateScore(ScoreSettings scoreSettings) {
         GameConfiguration gameConfiguration = GameConfiguration.getInstance();
-        int yearCount = gameConfiguration.getYearCount();
-        int currentScore = gameConfiguration.getScoreCount();
+        ScoreObserver scoreObserver = gameConfiguration.getScoreObserver();
+        YearsInPowerObserver yearsObserver = gameConfiguration.getYearsInPowerObserver();
+
+        int yearCount = yearsObserver.getYearsInPower();
+        int currentScore = scoreObserver.getScore();
 
         int scoreIncrease = scoreSettings.getBaseScoreIncrease();
 
@@ -42,6 +47,7 @@ public class HandleScore {
             scoreIncrease += bonusConfig.getBalancedBonus();
         }
 
-        gameConfiguration.setScoreCount(currentScore + scoreIncrease);
+        int newScore = currentScore + scoreIncrease;
+        scoreObserver.setScore(newScore);
     }
 }

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/handlers/SwipeHandler.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/handlers/SwipeHandler.java
@@ -5,16 +5,17 @@ import nl.vu.cs.ancientegyptiansgame.commands.GameSwipeCommand;
 import nl.vu.cs.ancientegyptiansgame.commands.IntroSwipeCommand;
 import nl.vu.cs.ancientegyptiansgame.data.enums.SwipeSide;
 import nl.vu.cs.ancientegyptiansgame.controller.GameStateController;
+import nl.vu.cs.ancientegyptiansgame.listeners.EndingListener;
 import nl.vu.cs.ancientegyptiansgame.ui.views.GameView;
 
 public class SwipeHandler {
 
     private final GameStateController gameStateController;
-    private final GameView gameView;
+    private final EndingListener endingListener;
 
-    public SwipeHandler(GameStateController gameStateController, GameView gameView) {
+    public SwipeHandler(GameStateController gameStateController, EndingListener endingListener) {
         this.gameStateController = gameStateController;
-        this.gameView = gameView;
+        this.endingListener = endingListener;
     }
 
     public void onSwipe(SwipeSide side) {
@@ -22,7 +23,7 @@ public class SwipeHandler {
         if (gameStateController.isIntroPhase()) {
             command = new IntroSwipeCommand(side, gameStateController);
         } else {
-            command = new GameSwipeCommand(side, gameStateController, gameView);
+            command = new GameSwipeCommand(side, gameStateController, endingListener);
         }
         command.execute();
     }

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/listeners/EndingListener.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/listeners/EndingListener.java
@@ -1,0 +1,7 @@
+package nl.vu.cs.ancientegyptiansgame.listeners;
+
+import nl.vu.cs.ancientegyptiansgame.data.model.Ending;
+
+public interface EndingListener {
+    void onEndingTriggered(Ending ending);
+}

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/listeners/ScoreListener.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/listeners/ScoreListener.java
@@ -1,0 +1,7 @@
+package nl.vu.cs.ancientegyptiansgame.listeners;
+
+public interface ScoreListener {
+
+    void changedScore(Integer newValue);
+
+}

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/listeners/YearsInPowerListener.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/listeners/YearsInPowerListener.java
@@ -1,0 +1,7 @@
+package nl.vu.cs.ancientegyptiansgame.listeners;
+
+public interface YearsInPowerListener {
+
+    void changedYears(Integer newValue);
+
+}

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/observer/PillarObserver.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/observer/PillarObserver.java
@@ -1,0 +1,32 @@
+package nl.vu.cs.ancientegyptiansgame.observer;
+
+import nl.vu.cs.ancientegyptiansgame.data.model.PillarData;
+import nl.vu.cs.ancientegyptiansgame.data.model.Pillars;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class PillarObserver {
+
+    private final EnumMap<Pillars, PillarData> pillars;
+
+    public PillarObserver() {
+        this.pillars = new EnumMap<>(Pillars.class);
+    }
+
+    public void addPillar(Pillars pillar, Integer initialValue) {
+        pillars.put(pillar, new PillarData(pillar, initialValue));
+    }
+
+    public void removePillar(Pillars pillar) {
+        pillars.remove(pillar);
+    }
+
+    public PillarData getPillarData(Pillars pillar) {
+        return pillars.get(pillar);
+    }
+
+    public Map<Pillars, PillarData> getAllPillars() {
+        return pillars;
+    }
+}

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/observer/ScoreObserver.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/observer/ScoreObserver.java
@@ -1,0 +1,42 @@
+package nl.vu.cs.ancientegyptiansgame.observer;
+
+import nl.vu.cs.ancientegyptiansgame.listeners.ScoreListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ScoreObserver {
+
+    private int score;
+    private final List<ScoreListener> listeners;
+
+    public ScoreObserver() {
+        this.score = 0;
+        this.listeners = new ArrayList<>();
+    }
+
+    public void addListener(ScoreListener listener) {
+        listeners.add(listener);
+    }
+
+    public void removeListener(ScoreListener listener) {
+        listeners.remove(listener);
+    }
+
+    public int getScore() {
+        return score;
+    }
+
+    public void setScore(int newScore) {
+        if (this.score != newScore) {
+            this.score = newScore;
+            notifyListeners();
+        }
+    }
+
+    private void notifyListeners() {
+        for (ScoreListener listener : listeners) {
+            listener.changedScore(score);
+        }
+    }
+}

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/observer/YearsInPowerObserver.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/observer/YearsInPowerObserver.java
@@ -1,0 +1,42 @@
+package nl.vu.cs.ancientegyptiansgame.observer;
+
+import nl.vu.cs.ancientegyptiansgame.listeners.YearsInPowerListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class YearsInPowerObserver {
+
+    private int yearsInPower;
+    private final List<YearsInPowerListener> listeners;
+
+    public YearsInPowerObserver() {
+        this.yearsInPower = 0;
+        this.listeners = new ArrayList<>();
+    }
+
+    public void addListener(YearsInPowerListener listener) {
+        listeners.add(listener);
+    }
+
+    public void removeListener(YearsInPowerListener listener) {
+        listeners.remove(listener);
+    }
+
+    public int getYearsInPower() {
+        return yearsInPower;
+    }
+
+    public void setYearsInPower(int newValue) {
+        if (this.yearsInPower != newValue) {
+            this.yearsInPower = newValue;
+            notifyListeners();
+        }
+    }
+
+    private void notifyListeners() {
+        for (YearsInPowerListener listener : listeners) {
+            listener.changedYears(yearsInPower);
+        }
+    }
+}

--- a/src/main/java/nl/vu/cs/ancientegyptiansgame/ui/views/PillarView.java
+++ b/src/main/java/nl/vu/cs/ancientegyptiansgame/ui/views/PillarView.java
@@ -3,6 +3,7 @@ package nl.vu.cs.ancientegyptiansgame.ui.views;
 import com.almasb.fxgl.dsl.FXGL;
 
 import com.almasb.fxgl.texture.Texture;
+import javafx.application.Platform;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.geometry.Rectangle2D;
@@ -93,11 +94,13 @@ public class PillarView extends StackPane {
 
         // Add a listener to update the progress image when the pillar value changes
         pillarData.addListener((updatedPillar, newValue) ->
-            adjustProgressImageSize(progressImage, newValue.doubleValue()));
+                Platform.runLater(() -> adjustProgressImageSize(progressImage, newValue.doubleValue()))
+        );
 
         progressImage.setEffect(getImageEffect());
         return progressImage;
     }
+
 
     private void adjustProgressImageSize(Texture progressImage, double progress) {
         double imageWidth = progressImage.getImage().getWidth();

--- a/src/main/resources/configuration/command_log.json
+++ b/src/main/resources/configuration/command_log.json
@@ -1,14 +1,14 @@
 [ {
   "commandType" : "IntroSwipeCommand",
   "cardTitle" : "choose-pharaoh",
-  "swipeDirection" : "RIGHT",
-  "timestamp" : 1743178461251,
-  "chosenCharacter" : "Tutankhamun"
+  "swipeDirection" : "LEFT",
+  "timestamp" : 1749045390012,
+  "chosenCharacter" : "Cleopatra"
 }, {
   "commandType" : "GameSwipeCommand",
   "cardTitle" : "Conscription",
   "swipeDirection" : "LEFT",
-  "timestamp" : 1743178462925,
+  "timestamp" : 1749045391814,
   "influence" : [ {
     "pillar" : "military",
     "value" : 2
@@ -20,16 +20,33 @@
   "scoreCount" : 1
 }, {
   "commandType" : "GameSwipeCommand",
-  "cardTitle" : "Mystical Ritual",
+  "cardTitle" : "Land Grants",
   "swipeDirection" : "RIGHT",
-  "timestamp" : 1743178463632,
+  "timestamp" : 1749045392763,
   "influence" : [ {
-    "pillar" : "priests",
+    "pillar" : "nobles",
     "value" : 2
   }, {
     "pillar" : "farmers",
-    "value" : -1
+    "value" : -2
   } ],
   "yearsInPower" : 20,
   "scoreCount" : 2
+}, {
+  "commandType" : "GameSwipeCommand",
+  "cardTitle" : "Trade Expedition",
+  "swipeDirection" : "LEFT",
+  "timestamp" : 1749045393690,
+  "influence" : [ {
+    "pillar" : "nobles",
+    "value" : 2
+  }, {
+    "pillar" : "military",
+    "value" : 2
+  }, {
+    "pillar" : "military",
+    "value" : -2
+  } ],
+  "yearsInPower" : 30,
+  "scoreCount" : 3
 } ]


### PR DESCRIPTION
In this pull request:

- Fixed the way pillarData and Observer are handled
- Created and implemented a listener/observer for the score and year so gameview updates the display every time there is an update --> no more function call and passing around gameView
-Created and implemented a listener for the ending. This way, endingHandler simply triggers an ending and gameview will show the correct endscreen without having to pass gameview to endingHandler.
Same for GameSwipeCommand that triggers the goldenage_ending or bad_ending